### PR TITLE
HACK: Make parceljs ignore the webpack-only `!raw-loader!` require

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ if (typeof webpackJsonp !== 'object') {
   pyjs = require('fs').readFileSync(__dirname + '/js.py').toString();
 }
 else {
-  pyjs = require('!raw-loader!./js.py').default;
+  pyjs = require('!raw-loader!' + './js.py').default;
 }
 
 function wait_exist(fn) {

--- a/lib/micropython.js
+++ b/lib/micropython.js
@@ -84,7 +84,7 @@ if (typeof webpackJsonp !== 'object') {
   Module.emterpreterFile = file.buffer.slice(file.byteOffset, file.byteOffset + file.byteLength);
 }
 else {
-  Module.emterpreterFile = require('!arraybuffer-loader!./micropython.binary');
+  Module.emterpreterFile = require('!arraybuffer-loader!' + './micropython.binary');
 }
 // Copyright 2010 The Emscripten Authors.  All rights reserved.
 // Emscripten is available under two separate licenses, the MIT license and the


### PR DESCRIPTION
The `if` surrounding the require of `!raw-loader!./js.py` should be enough to limit the processing of this line only by webpack. However, looks like parceljs is greedy and tries to follow such path. Then it fails for a code path that will never be executed by him.

The code change make parceljs ignore such require. Is not beautiful and should be replaced when parceljs provides something nicer.