### PR TITLE
Make it clear in README that do_str returns stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ import mp_js from 'micropython';
 (async () => {
   await mp_js;
   mp_js.init(64 * 1024);
-  mp_js.do_str("print('hello world')\n");
+  const stdout = await mp_js.do_str("print('hello world')\n");
+  console.log(stdout);
 })();
 ```
 


### PR DESCRIPTION
All the examples in the readme use `print` but don't show what happens to that text. Passing the returned result to `console.log` makes it clearer that the text is returned.